### PR TITLE
fix(pb): fix transaction sending failure with amount 0

### DIFF
--- a/pb/bxh_transaction.proto
+++ b/pb/bxh_transaction.proto
@@ -31,8 +31,8 @@ message TransactionData {
     Type type = 1;
     uint64 amount = 2;
     enum VMType {
-        BVM = 0;
-        XVM = 1;
+        XVM = 0;
+        BVM = 1;
     }
     VMType vm_type = 3;
     bytes payload = 4;


### PR DESCRIPTION
The type values of the BVM and XVM are swapped to avoid sending a normal BVM transaction with a payload of nil.